### PR TITLE
Apply Void Damage

### DIFF
--- a/src/main/java/net/nuggetmc/tplus/bot/Bot.java
+++ b/src/main/java/net/nuggetmc/tplus/bot/Bot.java
@@ -231,6 +231,9 @@ public class Bot extends EntityPlayer {
 
         fireDamageCheck();
         fallDamageCheck();
+        
+        if(locY() < -64)
+        	an();
 
         oldVelocity = velocity.clone();
     }


### PR DESCRIPTION
Fixes bots not receiving void damage, which causes them to be stuck falling forever.