### PR TITLE
Introduce /bot armor command

### DIFF
--- a/src/main/java/net/nuggetmc/tplus/command/commands/BotCommand.java
+++ b/src/main/java/net/nuggetmc/tplus/command/commands/BotCommand.java
@@ -206,7 +206,7 @@ public class BotCommand extends CommandInstance {
             armor = armorNetherite;
             break;
           default:
-            sender.sendMessage(ChatColor.RED + tier + ChatColor.RESET + " is not valid!");
+            sender.sendMessage(ChatColor.RED + tier + ChatColor.RESET + " is not a valid tier!");
             sender.sendMessage("Available Tiers: " + ChatColor.AQUA + "leather, chain, iron, gold, diamond, netherite");
             return;
         } 


### PR DESCRIPTION
### Feature Description
This PR aims to implement a tiered armor set and take advantage of that with a new command in the syntax `/bot armor <armor tier>`. Using the command with any armor tier will equip all existing bots with a full set of armor in the specified material.

**Command Example:** `/bot armor netherite`
**Command Result:** All Bots equip netherite armor
**Tier List:** `leather, chain, gold, iron, diamond, netherite`

### Additional Context
_Incorrect usage of the command will send the player a list of available tiers. The tiers are caps **insensitive** and are automatically converted into the desired armor group._

_This has been fully tested with all valid and non-valid tiers so players can have the piece of mind knowing that nothing will break._