### PR TITLE
fix ConcurrentModificationException

### DIFF
--- a/src/main/java/net/nuggetmc/tplus/bot/Bot.java
+++ b/src/main/java/net/nuggetmc/tplus/bot/Bot.java
@@ -498,7 +498,8 @@ public class Bot extends EntityPlayer {
 
     private void dieCheck() {
         if (removeOnDeath) {
-            scheduler.runTask(plugin, () -> plugin.getManager().remove(this)); // maybe making this later will fix the concurrentmodificationexception?
+            //scheduler.runTask(plugin, () -> plugin.getManager().remove(this)); // maybe making this later will fix the concurrentmodificationexception?
+            plugin.getManager().remove(this); //this should fix the concurrentmodificationexception mentioned above, I used the ConcurrentHashMap.newKeySet to make a "ConcurrentHashSet"
             scheduler.runTaskLater(plugin, this::setDead, 30);
 
             this.removeTab();

--- a/src/main/java/net/nuggetmc/tplus/bot/BotManager.java
+++ b/src/main/java/net/nuggetmc/tplus/bot/BotManager.java
@@ -18,6 +18,7 @@ import org.bukkit.util.Vector;
 
 import java.text.NumberFormat;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 public class BotManager implements Listener {
@@ -30,7 +31,7 @@ public class BotManager implements Listener {
 
     public BotManager() {
         this.agent = new LegacyAgent(this);
-        this.bots = new HashSet<>();
+        this.bots = ConcurrentHashMap.newKeySet();
         this.numberFormat = NumberFormat.getInstance(Locale.US);
     }
 


### PR DESCRIPTION
I had made this fix a while ago, didn't commit it. This doesn't seem to cause any problems for me.
I replaced the HashSet with ConcurrentHashMap.newKeySet which should create a "`ConcurrentHashSet`"