### PR TITLE
add "test" target goals

### DIFF
--- a/src/main/java/net/nuggetmc/tplus/bot/agent/legacyagent/EnumTargetGoal.java
+++ b/src/main/java/net/nuggetmc/tplus/bot/agent/legacyagent/EnumTargetGoal.java
@@ -4,14 +4,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 public enum EnumTargetGoal {
-    NEAREST_VULNERABLE_PLAYER("Locate the nearest real player that is in either Survival or Adventure mode."),
-    NEAREST_PLAYER("Locate the nearest real online player, despite the gamemode."),
-    NEAREST_HOSTILE("Locate the nearest hostile entity."),
-    NEAREST_MOB("Locate the nearest mob."),
-    NEAREST_BOT("Locate the nearest bot."),
-    NEAREST_BOT_DIFFER("Locate the nearest bot with a different username."),
-    NEAREST_BOT_DIFFER_ALPHA("Locate the nearest bot with a different username after filtering out non-alpha characters."),
-    NONE("No target goal.");
+    NEAREST_VULNERABLE_PLAYER("Locate the nearest real player that is in either Survival or Adventure mode.",false),
+    NEAREST_PLAYER("Locate the nearest real online player, despite the gamemode.",false),
+    NEAREST_HOSTILE("Locate the nearest hostile entity.",false),
+    NEAREST_MOB("Locate the nearest mob.",false),
+    NEAREST_BOT("Locate the nearest bot.",false),
+    NEAREST_BOT_DIFFER("Locate the nearest bot with a different username.",false),
+    NEAREST_BOT_DIFFER_ALPHA("Locate the nearest bot with a different username after filtering out non-alpha characters.",false),
+    NONE("No target goal.",false);
 
     private static final Map<String, EnumTargetGoal> VALUES = new HashMap<String, EnumTargetGoal>() {
         {
@@ -27,9 +27,15 @@ public enum EnumTargetGoal {
     };
 
     private final String description;
+    private final boolean test;
 
-    EnumTargetGoal(String description) {
+    EnumTargetGoal(String description,boolean test) {
         this.description = description;
+        this.test = test;
+    }
+
+    public boolean isTest() {
+        return test;
     }
 
     public static EnumTargetGoal from(String name) {

--- a/src/main/java/net/nuggetmc/tplus/bot/agent/legacyagent/LegacyAgent.java
+++ b/src/main/java/net/nuggetmc/tplus/bot/agent/legacyagent/LegacyAgent.java
@@ -2,6 +2,7 @@ package net.nuggetmc.tplus.bot.agent.legacyagent;
 
 import net.minecraft.server.v1_16_R3.BlockPosition;
 import net.minecraft.server.v1_16_R3.PacketPlayOutBlockBreakAnimation;
+import net.minecraft.server.v1_16_R3.PathfinderGoal;
 import net.nuggetmc.tplus.bot.Bot;
 import net.nuggetmc.tplus.bot.BotManager;
 import net.nuggetmc.tplus.bot.agent.Agent;
@@ -1134,6 +1135,8 @@ public class LegacyAgent extends Agent {
 
         switch (goal) {
             default:
+                return null;
+            case NONE:
                 return null;
 
             case NEAREST_PLAYER: {

--- a/src/main/java/net/nuggetmc/tplus/command/commands/BotCommand.java
+++ b/src/main/java/net/nuggetmc/tplus/command/commands/BotCommand.java
@@ -342,8 +342,12 @@ public class BotCommand extends CommandInstance {
         if (goal == null) {
             sender.sendMessage(ChatUtils.LINE);
             sender.sendMessage(ChatColor.GOLD + "Goal Selection Types" + extra);
-            Arrays.stream(EnumTargetGoal.values()).forEach(g -> sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + g.name().replace("_", "").toLowerCase()
-                    + ChatUtils.BULLET_FORMATTED + g.description()));
+            Arrays.stream(EnumTargetGoal.values()).forEach(g -> {
+                if (g.isTest())
+                    return;
+                sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + g.name().replace("_", "").toLowerCase()
+                        + ChatUtils.BULLET_FORMATTED + g.description());
+            });
             sender.sendMessage(ChatUtils.LINE);
             return;
         }
@@ -371,7 +375,11 @@ public class BotCommand extends CommandInstance {
 
         else if (args.length == 3) {
             if (args[1].equalsIgnoreCase("setgoal")) {
-                Arrays.stream(EnumTargetGoal.values()).forEach(goal -> output.add(goal.name().replace("_", "").toLowerCase()));
+                Arrays.stream(EnumTargetGoal.values()).forEach(goal -> {
+                    if (goal.isTest())
+                        return; //don't show test goals
+                    output.add(goal.name().replace("_", "").toLowerCase());
+                });
             }
         }
 


### PR DESCRIPTION
What test target goals are:
This PR makes it possible to specify goals as "tests", test goals are hidden from `/bot settings setgoal`, but are still accessible from the command. I made this because the bot gets it's target from LegacyAgent#locateTarget. Adding these "test goals" make it easier to add debug goals and saves time adding more code.