### PR TITLE
Updated jumping logic so bots can jump over blocks

### DIFF
--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/Bot.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/Bot.java
@@ -450,7 +450,9 @@ public class Bot extends ServerPlayer implements Terminator {
                 y = 0;
             } else {
                 y = velocity.getY();
-                velocity.setY(Math.max(y - 0.1, -3.5));
+                if(jumpTicks - 3 <= 0) {
+                    velocity.setY(Math.max(y - 0.08, -3.5));
+                }
             }
         }
 
@@ -484,7 +486,7 @@ public class Bot extends ServerPlayer implements Terminator {
 
     @Override
     public void jump() {
-        jump(new Vector(0, 0.5, 0));
+        jump(new Vector(0, 0.42, 0));
     }
 
     @Override

--- a/buildSrc/src/main/kotlin/net.nuggetmc.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/net.nuggetmc.java-conventions.gradle.kts
@@ -3,4 +3,4 @@ plugins {
 }
 
 group = "net.nuggetmc"
-version = "4.5.0-BETA"
+version = "4.5.1-BETA"


### PR DESCRIPTION
& Updated patch version +1.

It seems that setting the y in the updateLocation method was changing the velocity of the jumping bot too fast, preventing the bot from jumping one block. By adding an if statement that checks if jumpTicks - 3 is 0 or lower (it is hardcoded to 4 when a bot jumps), this allows the bot to jump for a full tick.